### PR TITLE
migrate from Grpc.Core to Grpc.Net.Client

### DIFF
--- a/examples/YandexCloud.IamJwtCredentials.Demo/YandexCloud.IamJwtCredentials.Demo.csproj
+++ b/examples/YandexCloud.IamJwtCredentials.Demo/YandexCloud.IamJwtCredentials.Demo.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YandexCloud.IamJwtCredentials" Version="1.0.1" />
+    <PackageReference Include="YandexCloud.IamJwtCredentials" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/YandexCloud.IamJwtCredentials.Demo/authorized_key.json
+++ b/examples/YandexCloud.IamJwtCredentials.Demo/authorized_key.json
@@ -1,7 +1,7 @@
 {
   "id": "***",
-  "service_account_id": ""***",",
-  "created_at": ""***",",
+  "service_account_id": "***",
+  "created_at": "***",
   "key_algorithm": "RSA_2048",
   "public_key": "***",
   "private_key": "***"

--- a/src/YandexCloud.SDK.IamJwtCredentials/IamJwtCredentialsConfiguration.cs
+++ b/src/YandexCloud.SDK.IamJwtCredentials/IamJwtCredentialsConfiguration.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace YandexCloud.IamJwtCredentials
 {
@@ -23,6 +18,5 @@ namespace YandexCloud.IamJwtCredentials
 
         [JsonPropertyName("private_key")]
         public string PrivateKey { get; set; }
-        
     }
 }

--- a/src/YandexCloud.SDK.IamJwtCredentials/IamJwtCredentialsProvider.cs
+++ b/src/YandexCloud.SDK.IamJwtCredentials/IamJwtCredentialsProvider.cs
@@ -1,4 +1,4 @@
-﻿using Grpc.Core;
+﻿using Grpc.Net.Client;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using System.Security.Cryptography;
@@ -9,7 +9,7 @@ namespace YandexCloud.IamJwtCredentials
 {
     public class IamJwtCredentialsProvider : ICredentialsProvider
     {
-        private const string IamApiCloud ="iam.api.cloud.yandex.net:443";
+        private const string IamApiCloud = "iam.api.cloud.yandex.net";
 
         private readonly string _keyId;
         private readonly string _pemCertificate;
@@ -27,7 +27,6 @@ namespace YandexCloud.IamJwtCredentials
 
         public IamJwtCredentialsProvider(IamJwtCredentialsConfiguration configuration)
             : this(configuration.ServiceAccountId, configuration.Id, configuration.PrivateKey) { }
-        
 
         public IamJwtCredentialsProvider(string serviceAccountId, string keyId, string pemCertificate,
             IamTokenService.IamTokenServiceClient tokenService)
@@ -50,9 +49,9 @@ namespace YandexCloud.IamJwtCredentials
             return _iamToken.IamToken;
         }
 
-        private IamTokenService.IamTokenServiceClient TokenService()
+        private static IamTokenService.IamTokenServiceClient TokenService()
         {
-            var channel = new Grpc.Core.Channel(IamApiCloud, new SslCredentials());
+            var channel = GrpcChannel.ForAddress($"https://{IamApiCloud}");
             return new IamTokenService.IamTokenServiceClient(channel);
         }
 
@@ -72,7 +71,7 @@ namespace YandexCloud.IamJwtCredentials
             var descriptor = new SecurityTokenDescriptor
             {
                 Issuer = _serviceAccountId,
-                Audience = "https://iam.api.cloud.yandex.net/iam/v1/tokens",
+                Audience = $"https://{IamApiCloud}/iam/v1/tokens",
                 IssuedAt = now,
                 NotBefore = now,
                 Expires = now.AddMinutes(60),
@@ -81,7 +80,5 @@ namespace YandexCloud.IamJwtCredentials
 
             return handler.CreateToken(descriptor);
         }
-
-
     }
 }

--- a/src/YandexCloud.SDK.IamJwtCredentials/YandexCloud.IamJwtCredentials.csproj
+++ b/src/YandexCloud.SDK.IamJwtCredentials/YandexCloud.IamJwtCredentials.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<Version>1.0.2</Version>
-	<Authors>Roman Shershnev</Authors>
-	<RepositoryUrl>https://github.com/RVShershnev/yc-sdk-iam-jwt-credentials</RepositoryUrl>
-	<Tags>Yandex Cloud</Tags>
-	<GenerateDocumentationFile>True</GenerateDocumentationFile>
-	<SignAssembly>False</SignAssembly>
-	<Title>YandexCloud.IamJWTCredentials</Title>
-	<PackageProjectUrl>https://github.com/RVShershnev/yc-sdk-iam-jwt-credentials</PackageProjectUrl>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<PackageTags>Yandex Cloud;Jwt</PackageTags>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Copyright>Roman Shershnev</Copyright>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Version>1.0.2</Version>
+    <Authors>Roman Shershnev</Authors>
+    <RepositoryUrl>https://github.com/RVShershnev/yc-sdk-iam-jwt-credentials</RepositoryUrl>
+    <Tags>Yandex Cloud</Tags>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <SignAssembly>False</SignAssembly>
+    <Title>YandexCloud.IamJWTCredentials</Title>
+    <PackageProjectUrl>https://github.com/RVShershnev/yc-sdk-iam-jwt-credentials</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>Yandex Cloud;Jwt</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Roman Shershnev</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,13 +24,12 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-	  
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.26.*" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.26.*" />
-    <PackageReference Include="Yandex.Cloud.SDK" Version="1.2.*" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.13.*"/>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.13.*"/>
+    <PackageReference Include="Yandex.Cloud.SDK" Version="1.4.*"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- migrate from Grpc.Core to Grpc.Net.Client
- update vulnerable packages
- migrate projects to .net8 (LTS release)